### PR TITLE
fix: diff error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,18 @@ func main() {
 		return c.Run()
 	}
 
-	if err := cmd.Execute(); err != nil {
-		log.Fatalln("Error:", err)
+	err := cmd.Execute()
+
+	// diff command always return exit 1, when diff is succeeded
+	if err != nil {
+		switch err.(type) {
+		case *exec.ExitError:
+			// this is just an exit code error, no worries
+			// do nothing
+
+		default: //couldn't run diff
+			log.Fatalln("Error:", err)
+		}
 	}
 }
 


### PR DESCRIPTION
kubectl diff always return exit 1 code when it is succeeded, so stdout always displays "Error: exit status 1" messages.
This PR makes it to disabled to display "Error: exit status 1" messages.

```diff
❯ export KUBECTL_EXTERNAL_DIFF=kubectl-neat-diff
❯ kubectl diff -f /tmp/cert-manager.yaml
diff -uN /var/folders/md/3c1mvffj38l1hbxcnr1xtnyw0000gq/T/LIVE-853494148/apiextensions.k8s.io.v1.CustomResourceDefinition..certificaterequests.cert-manager.io /var/folders/md/3c1mvffj38l1hbxcnr1xtnyw0000gq/T/MERGED-517238035/apiextensions.k8s.io.v1.CustomResourceDefinition..certificaterequests.cert-manager.io
--- /var/folders/md/3c1mvffj38l1hbxcnr1xtnyw0000gq/T/LIVE-853494148/apiextensions.k8s.io.v1.CustomResourceDefinition..certificaterequests.cert-manager.io   2021-08-23 21:32:06.000000000 +0900
+++ /var/folders/md/3c1mvffj38l1hbxcnr1xtnyw0000gq/T/MERGED-517238035/apiextensions.k8s.io.v1.CustomResourceDefinition..certificaterequests.cert-manager.io 2021-08-23 21:32:06.000000000 +0900
@@ -4,7 +4,7 @@
   annotations:
     cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
   labels:
-    app: cert-manager
+    app: cert-manageraaa
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
   name: certificaterequests.cert-manager.io
Error: exit status 1.  <------⭐️
```

