### PR TITLE
Support diffing files

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -73,7 +72,7 @@ func neatifyDir(dir string) error {
 	return nil
 }
 
-func neatifyFile(filename string, mode fs.FileMode) error {
+func neatifyFile(filename string, mode os.FileMode) error {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
Until now `kubectl-neat-diff` only supported diffing directories of files.
This PR makes "neatify" recursive so we can also diff files.

This new behavior is closer to how "diff-like" command should behave.
Plus it will allow `kubectl-neat-diff` to be used for static diffing in tanka - see this PR for more context: https://github.com/grafana/tanka/pull/558

Additionally, if we allowed `--recursive` to be passed to the `diff` command we would get fully recursive "neat" diff.

Just for the record I've tested the change.